### PR TITLE
Replace deprecated

### DIFF
--- a/Run.java
+++ b/Run.java
@@ -3,7 +3,7 @@ import org.antlr.v4.runtime.tree.*;
 
 public class Run {
     public static void main(String[] args) throws Exception {
-        ANTLRInputStream input = new ANTLRInputStream(System.in);
+        CharStream input = CharStreams.fromStream(System.in);
         CalculatorLexer lexer = new CalculatorLexer(input);
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         CalculatorParser parser = new CalculatorParser(tokens);


### PR DESCRIPTION
Using `CharStream` instead of `ANTLRInputStream`.

`ANTLRInputStream` has been deprecated since ANTLR 4.7.

See [ANTLRInputStream (ANTLR 4 Runtime 4.7.1 API)](http://www.antlr.org/api/Java/org/antlr/v4/runtime/ANTLRInputStream.html).